### PR TITLE
02 - Feat/go routines exercise

### DIFF
--- a/internal/exercises/catalog.yaml
+++ b/internal/exercises/catalog.yaml
@@ -134,6 +134,12 @@ concepts:
   test_regex: ".*"
   hints:
     - Define a custom error type and return it from a function.
+- slug: 28_defer
+  title: Defer
+  test_regex: ".*"
+  hints:
+    - Use `f.close()` with `defer` keyword.
+    
 - slug: 37_xml
   title: XML Encoding and Decoding
   test_regex: ".*"

--- a/internal/exercises/catalog.yaml
+++ b/internal/exercises/catalog.yaml
@@ -139,7 +139,12 @@ concepts:
   test_regex: ".*"
   hints:
     - Use `f.close()` with `defer` keyword.
-    
+- slug: 29_go_routines
+  title: Go Routines
+  test_regex: ".*"
+  hints:
+    - Use `go` keyword to execute functions concurrently using go routines.
+
 - slug: 37_xml
   title: XML Encoding and Decoding
   test_regex: ".*"

--- a/internal/exercises/solutions/28_defer/defer.go
+++ b/internal/exercises/solutions/28_defer/defer.go
@@ -1,0 +1,29 @@
+package deferr
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+var (
+	fileInstance *os.File
+	once         sync.Once
+)
+
+func CreateFile() *os.File {
+	once.Do(func() {
+		f, err := os.CreateTemp("", "example.txt")
+		if err != nil {
+			panic(err)
+		}
+		fileInstance = f
+	})
+	return fileInstance
+}
+
+func WriteToFile(*os.File) {
+	f := CreateFile()
+	defer f.Close()
+	fmt.Fprintln(f, "data")
+}

--- a/internal/exercises/solutions/29_go_routines/go_routines.go
+++ b/internal/exercises/solutions/29_go_routines/go_routines.go
@@ -1,0 +1,25 @@
+package go_routines
+
+import (
+	"time"
+)
+
+func sleepForOneHundredMillisecond() {
+	time.Sleep(100 * time.Millisecond)
+}
+
+func sleepForTwoHundredMilliseconds() {
+	time.Sleep(200 * time.Millisecond)
+}
+
+func RunConcurrently() {
+	go sleepForOneHundredMillisecond()
+	go sleepForTwoHundredMilliseconds()
+
+	// go func() {
+	// 	sleepForOneHundredMillisecond()
+	// }()
+	// go func() {
+	// 	sleepForTwoHundredMilliseconds()
+	// }()
+}

--- a/internal/exercises/templates/28_defer/defer.go
+++ b/internal/exercises/templates/28_defer/defer.go
@@ -1,0 +1,29 @@
+package deferr
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+var (
+	fileInstance *os.File
+	once         sync.Once
+)
+
+func CreateFile() *os.File {
+	once.Do(func() {
+		f, err := os.CreateTemp("", "example.txt")
+		if err != nil {
+			panic(err)
+		}
+		fileInstance = f
+	})
+	return fileInstance
+}
+
+func WriteToFile(*os.File) {
+	f := CreateFile()
+	// TODO: Add your code here
+	fmt.Fprintln(f, "data")
+}

--- a/internal/exercises/templates/28_defer/defer_test.go
+++ b/internal/exercises/templates/28_defer/defer_test.go
@@ -1,0 +1,17 @@
+package deferr
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestClosingFileAfterWriting(t *testing.T) {
+	f := CreateFile()
+	WriteToFile(f)
+
+	// trying to write to the file after closing
+	_, err := fmt.Fprintln(f, "data")
+	if err == nil {
+		t.Fatal("File wasn't closed!")
+	}
+}

--- a/internal/exercises/templates/29_go_routines/go_routines.go
+++ b/internal/exercises/templates/29_go_routines/go_routines.go
@@ -1,0 +1,19 @@
+package go_routines
+
+import (
+	"time"
+)
+
+func sleepForOneHundredMillisecond() {
+	time.Sleep(100 * time.Millisecond)
+}
+
+func sleepForTwoHundredMilliseconds() {
+	time.Sleep(200 * time.Millisecond)
+}
+
+func RunConcurrently() {
+	// TODO: update following code
+	sleepForOneHundredMillisecond()
+	sleepForTwoHundredMilliseconds()
+}

--- a/internal/exercises/templates/29_go_routines/go_routines_test.go
+++ b/internal/exercises/templates/29_go_routines/go_routines_test.go
@@ -1,0 +1,24 @@
+package go_routines
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGoRoutines(t *testing.T) {
+	start := time.Now()
+	RunConcurrently()
+	elapsed := time.Since(start)
+
+	// according to benchmark it is about ~2 microseconds
+	// x2 for more breathing room, so 4
+	if elapsed.Microseconds() >= 4 {
+		t.Fatal("Go routines was not used!")
+	}
+}
+
+func BenchmarkRunConcurrently(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		RunConcurrently()
+	}
+}


### PR DESCRIPTION
## Summary

Adds go routines exercise.

## Checklist

- [x] Tests pass: `make verify` or `golearn verify <slug>` (**CLI does not work as said in an issue, but tested locally using `go test`**.)
- [x] Docs updated (README/CONTRIBUTING) if needed
- [x] No large new dependencies

## Screenshots / Output (if CLI UX)

Paste before/after where helpful.

## Related issues

Fixes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new concept exercises: "Defer" (resource cleanup with defer) and "Go Routines" (basic concurrent execution).
  * Each exercise includes a starter template and an example solution to guide learning.

* **Tests**
  * Both exercises are bundled with automated tests and a benchmark to validate expected behavior.

* **Chores**
  * Catalog updated to list the new exercises.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->