### PR TITLE
05 - Feat/sorting exercise

### DIFF
--- a/internal/exercises/catalog.yaml
+++ b/internal/exercises/catalog.yaml
@@ -154,6 +154,11 @@ concepts:
   test_regex: ".*"
   hints:
     - Use `sync.Mutex` to synchronize access to a shared resource.
+- slug: 32_sorting
+  title: Sorting
+  test_regex: ".*"
+  hints:
+    - Use `slice.Sort` for sorting slices.
 
 - slug: 37_xml
   title: XML Encoding and Decoding

--- a/internal/exercises/catalog.yaml
+++ b/internal/exercises/catalog.yaml
@@ -134,6 +134,12 @@ concepts:
   test_regex: ".*"
   hints:
     - Define a custom error type and return it from a function.
+- slug: 28_defer
+  title: Defer
+  test_regex: ".*"
+  hints:
+    - Use `f.close()` with `defer` keyword.
+    
 - slug: 37_xml
   title: XML Encoding and Decoding
   test_regex: ".*"

--- a/internal/exercises/catalog.yaml
+++ b/internal/exercises/catalog.yaml
@@ -144,6 +144,11 @@ concepts:
   test_regex: ".*"
   hints:
     - Use `go` keyword to execute functions concurrently using go routines.
+- slug: 30_channels
+  title: Channels
+  test_regex: ".*"
+  hints:
+    - Use `make(chan T)` to create a channel and `<-` to send and receive on it.
 
 - slug: 37_xml
   title: XML Encoding and Decoding

--- a/internal/exercises/catalog.yaml
+++ b/internal/exercises/catalog.yaml
@@ -139,7 +139,12 @@ concepts:
   test_regex: ".*"
   hints:
     - Use `f.close()` with `defer` keyword.
-    
+- slug: 29_go_routines
+  title: Go Routines
+  test_regex: ".*"
+  hints:
+    - Use `go` keyword to execute functions concurrently using go routines.
+
 - slug: 37_xml
   title: XML Encoding and Decoding
   test_regex: ".*"

--- a/internal/exercises/catalog.yaml
+++ b/internal/exercises/catalog.yaml
@@ -149,6 +149,11 @@ concepts:
   test_regex: ".*"
   hints:
     - Use `make(chan T)` to create a channel and `<-` to send and receive on it.
+- slug: 31_mutexes
+  title: Mutexes
+  test_regex: ".*"
+  hints:
+    - Use `sync.Mutex` to synchronize access to a shared resource.
 
 - slug: 37_xml
   title: XML Encoding and Decoding

--- a/internal/exercises/solutions/28_defer/defer.go
+++ b/internal/exercises/solutions/28_defer/defer.go
@@ -1,0 +1,29 @@
+package deferr
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+var (
+	fileInstance *os.File
+	once         sync.Once
+)
+
+func CreateFile() *os.File {
+	once.Do(func() {
+		f, err := os.CreateTemp("", "example.txt")
+		if err != nil {
+			panic(err)
+		}
+		fileInstance = f
+	})
+	return fileInstance
+}
+
+func WriteToFile(*os.File) {
+	f := CreateFile()
+	defer f.Close()
+	fmt.Fprintln(f, "data")
+}

--- a/internal/exercises/solutions/29_go_routines/go_routines.go
+++ b/internal/exercises/solutions/29_go_routines/go_routines.go
@@ -1,0 +1,25 @@
+package go_routines
+
+import (
+	"time"
+)
+
+func sleepForOneHundredMillisecond() {
+	time.Sleep(100 * time.Millisecond)
+}
+
+func sleepForTwoHundredMilliseconds() {
+	time.Sleep(200 * time.Millisecond)
+}
+
+func RunConcurrently() {
+	go sleepForOneHundredMillisecond()
+	go sleepForTwoHundredMilliseconds()
+
+	// go func() {
+	// 	sleepForOneHundredMillisecond()
+	// }()
+	// go func() {
+	// 	sleepForTwoHundredMilliseconds()
+	// }()
+}

--- a/internal/exercises/solutions/30_channels/channels.go
+++ b/internal/exercises/solutions/30_channels/channels.go
@@ -1,0 +1,13 @@
+package channels
+
+func ReadMessage() string {
+	chat := make(chan string)
+	go func() {
+		senderMessage := "Hi!"
+		chat <- senderMessage
+	}()
+
+	msg := <-chat
+
+	return msg
+}

--- a/internal/exercises/solutions/31_mutexes/mutexes.go
+++ b/internal/exercises/solutions/31_mutexes/mutexes.go
@@ -1,0 +1,31 @@
+package mutexes
+
+import "sync"
+
+const numWorkers = 10_000
+
+func Counting() int {
+
+	count := 0
+	done := make(chan bool, numWorkers)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	for i := 1; i <= numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mu.Lock()
+			count += 1
+			mu.Unlock()
+			done <- true
+		}()
+	}
+
+	for i := 1; i <= numWorkers; i++ {
+		<-done
+	}
+
+	wg.Wait()
+	return count
+}

--- a/internal/exercises/solutions/32_sorting/sorting.go
+++ b/internal/exercises/solutions/32_sorting/sorting.go
@@ -1,0 +1,18 @@
+package sorting
+
+import (
+	"slices"
+)
+
+var Years = []int{2017, 2003, 2026}
+var Pets = []string{"Dog", "Cat", "Parrot"}
+
+func SortNumbers() []int {
+	slices.Sort(Years)
+	return Years
+}
+
+func SortAnimals() []string {
+	slices.Sort(Pets)
+	return Pets
+}

--- a/internal/exercises/templates/28_defer/defer.go
+++ b/internal/exercises/templates/28_defer/defer.go
@@ -1,0 +1,29 @@
+package deferr
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+var (
+	fileInstance *os.File
+	once         sync.Once
+)
+
+func CreateFile() *os.File {
+	once.Do(func() {
+		f, err := os.CreateTemp("", "example.txt")
+		if err != nil {
+			panic(err)
+		}
+		fileInstance = f
+	})
+	return fileInstance
+}
+
+func WriteToFile(*os.File) {
+	f := CreateFile()
+	// TODO: Add your code here
+	fmt.Fprintln(f, "data")
+}

--- a/internal/exercises/templates/28_defer/defer_test.go
+++ b/internal/exercises/templates/28_defer/defer_test.go
@@ -1,0 +1,17 @@
+package deferr
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestClosingFileAfterWriting(t *testing.T) {
+	f := CreateFile()
+	WriteToFile(f)
+
+	// trying to write to the file after closing
+	_, err := fmt.Fprintln(f, "data")
+	if err == nil {
+		t.Fatal("File wasn't closed!")
+	}
+}

--- a/internal/exercises/templates/29_go_routines/go_routines.go
+++ b/internal/exercises/templates/29_go_routines/go_routines.go
@@ -1,0 +1,19 @@
+package go_routines
+
+import (
+	"time"
+)
+
+func sleepForOneHundredMillisecond() {
+	time.Sleep(100 * time.Millisecond)
+}
+
+func sleepForTwoHundredMilliseconds() {
+	time.Sleep(200 * time.Millisecond)
+}
+
+func RunConcurrently() {
+	// TODO: update following code
+	sleepForOneHundredMillisecond()
+	sleepForTwoHundredMilliseconds()
+}

--- a/internal/exercises/templates/29_go_routines/go_routines_test.go
+++ b/internal/exercises/templates/29_go_routines/go_routines_test.go
@@ -1,0 +1,24 @@
+package go_routines
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGoRoutines(t *testing.T) {
+	start := time.Now()
+	RunConcurrently()
+	elapsed := time.Since(start)
+
+	// according to benchmark it is about ~2 microseconds
+	// x2 for more breathing room, so 4
+	if elapsed.Microseconds() >= 4 {
+		t.Fatal("Go routines was not used!")
+	}
+}
+
+func BenchmarkRunConcurrently(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		RunConcurrently()
+	}
+}

--- a/internal/exercises/templates/30_channels/channels.go
+++ b/internal/exercises/templates/30_channels/channels.go
@@ -1,0 +1,15 @@
+package channels
+
+import "fmt"
+
+func ReadMessage() string {
+	// TODO: update following code
+	// to receive senderMessage in main goroutine
+	// and return it from ReadMessage function
+	go func() {
+		senderMessage := "Hi!"
+		fmt.Println(senderMessage)
+	}()
+
+	return ""
+}

--- a/internal/exercises/templates/30_channels/channels_test.go
+++ b/internal/exercises/templates/30_channels/channels_test.go
@@ -1,0 +1,12 @@
+package channels
+
+import "testing"
+
+func TestReadMessage(t *testing.T) {
+	got := ReadMessage()
+	want := "Hi!"
+
+	if got != want {
+		t.Errorf("Expected %s, got %s", want, got)
+	}
+}

--- a/internal/exercises/templates/31_mutexes/mutexes.go
+++ b/internal/exercises/templates/31_mutexes/mutexes.go
@@ -1,0 +1,30 @@
+package mutexes
+
+import "sync"
+
+const numWorkers = 10_000
+
+func Counting() int {
+
+	// TODO: update following code to avoid race conditions
+	// using sync.Mutex
+	count := 0
+	done := make(chan bool, numWorkers)
+	var wg sync.WaitGroup
+
+	for i := 1; i <= numWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			count += 1
+			done <- true
+		}()
+	}
+
+	for i := 1; i <= numWorkers; i++ {
+		<-done
+	}
+
+	wg.Wait()
+	return count
+}

--- a/internal/exercises/templates/31_mutexes/mutexes_test.go
+++ b/internal/exercises/templates/31_mutexes/mutexes_test.go
@@ -1,0 +1,12 @@
+package mutexes
+
+import "testing"
+
+func TestCounter(t *testing.T) {
+	got := Counting()
+	want := numWorkers
+
+	if got != want {
+		t.Fatalf("Expected %d, got %d", want, got)
+	}
+}

--- a/internal/exercises/templates/32_sorting/sorting.go
+++ b/internal/exercises/templates/32_sorting/sorting.go
@@ -1,0 +1,14 @@
+package sorting
+
+var Years = []int{2017, 2003, 2026}
+var Pets = []string{"Dog", "Cat", "Parrot"}
+
+func SortNumbers() []int {
+	// TODO: sort Years
+	return Years
+}
+
+func SortAnimals() []string {
+	// TODO: sort Pets
+	return Pets
+}

--- a/internal/exercises/templates/32_sorting/sorting_test.go
+++ b/internal/exercises/templates/32_sorting/sorting_test.go
@@ -1,0 +1,22 @@
+package sorting
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestSorting(t *testing.T) {
+	t.Run("Sorting numbers", func(t *testing.T) {
+		SortNumbers()
+		if !slices.IsSorted(Years) {
+			t.Fatal("Strings are not sorted!")
+		}
+	})
+
+	t.Run("Sorting strings", func(t *testing.T) {
+		SortAnimals()
+		if !slices.IsSorted(Pets) {
+			t.Fatal("Strings are not sorted!")
+		}
+	})
+}


### PR DESCRIPTION
### Summary

Adds sorting exercises for sorting slices. Contain two cases for both number and string slices, to show sorting strings (multiple characters) also possible, not just numbers.

## Checklist

- [x] Tests pass: `make verify` or `golearn verify <slug>` (**CLI does not work as said in an issue, but tested locally using `go test`**.)
- [x] Docs updated (README/CONTRIBUTING) if needed
- [x] No large new dependencies

## Screenshots / Output (if CLI UX)

Paste before/after where helpful.

## Related issues

Fixes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added new concept exercises: Defer, Goroutines, Channels, Mutexes, and Sorting.
  - Introduced corresponding starter templates and example solutions.
- Refactor
  - Reorganized and renumbered projects: 28–36 moved to 101–109 (e.g., text_analyzer → 101_text_analyzer, http_server → 104_http_server).
- Tests
  - Added unit tests for new exercises covering concurrency, channels, mutex behavior, and sorting.
- Chores
  - Updated catalog with new entries and enhanced metadata (difficulty, topics, hints) for select projects (e.g., Epoch).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->