### PR TITLE
01 - Added defer exercise back

### DIFF
--- a/internal/exercises/catalog.yaml
+++ b/internal/exercises/catalog.yaml
@@ -134,6 +134,12 @@ concepts:
   test_regex: ".*"
   hints:
     - Define a custom error type and return it from a function.
+- slug: 28_defer
+  title: Defer
+  test_regex: ".*"
+  hints:
+    - Use `f.close()` with `defer` keyword.
+    
 - slug: 37_xml
   title: XML Encoding and Decoding
   test_regex: ".*"

--- a/internal/exercises/solutions/28_defer/defer.go
+++ b/internal/exercises/solutions/28_defer/defer.go
@@ -1,0 +1,29 @@
+package deferr
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+var (
+	fileInstance *os.File
+	once         sync.Once
+)
+
+func CreateFile() *os.File {
+	once.Do(func() {
+		f, err := os.CreateTemp("", "example.txt")
+		if err != nil {
+			panic(err)
+		}
+		fileInstance = f
+	})
+	return fileInstance
+}
+
+func WriteToFile(*os.File) {
+	f := CreateFile()
+	defer f.Close()
+	fmt.Fprintln(f, "data")
+}

--- a/internal/exercises/templates/28_defer/defer.go
+++ b/internal/exercises/templates/28_defer/defer.go
@@ -1,0 +1,29 @@
+package deferr
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+var (
+	fileInstance *os.File
+	once         sync.Once
+)
+
+func CreateFile() *os.File {
+	once.Do(func() {
+		f, err := os.CreateTemp("", "example.txt")
+		if err != nil {
+			panic(err)
+		}
+		fileInstance = f
+	})
+	return fileInstance
+}
+
+func WriteToFile(*os.File) {
+	f := CreateFile()
+	// TODO: Add your code here
+	fmt.Fprintln(f, "data")
+}

--- a/internal/exercises/templates/28_defer/defer_test.go
+++ b/internal/exercises/templates/28_defer/defer_test.go
@@ -1,0 +1,17 @@
+package deferr
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestClosingFileAfterWriting(t *testing.T) {
+	f := CreateFile()
+	WriteToFile(f)
+
+	// trying to write to the file after closing
+	_, err := fmt.Fprintln(f, "data")
+	if err == nil {
+		t.Fatal("File wasn't closed!")
+	}
+}


### PR DESCRIPTION
## Summary

Added reverted defer exercise

## Checklist

- [x] Tests pass: `make verify` or `golearn verify <slug>`
- [x] Docs updated (README/CONTRIBUTING) if needed
- [x] No large new dependencies

## Screenshots / Output (if CLI UX)

Paste before/after where helpful.

## Related issues

Fixes #75 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "Defer" concept to the exercises catalog.
  * Introduced an exercise demonstrating creating/writing a temporary file and proper resource handling using defer.
  * Added learner hints about using defer to close files.

* **Tests**
  * Added automated tests to verify file closure and expected behavior after writing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->