### PR TITLE
feat: Add solution for exercise 16_range_built_in (#25)

### DIFF
--- a/internal/exercises/solutions/16_range_built_in/range_built_in.go
+++ b/internal/exercises/solutions/16_range_built_in/range_built_in.go
@@ -1,0 +1,19 @@
+package range_built_in
+
+// sumSlice returns the sum of all elements in the slice using range
+func sumSlice(s []int) int {
+	sum := 0
+	for _, v := range s {
+		sum += v
+	}
+	return sum
+}
+
+// countMap returns the number of key/value pairs in the map using range
+func countMap(m map[string]int) int {
+	count := 0
+	for range m {
+		count++
+	}
+	return count
+}


### PR DESCRIPTION
## Summary

  Implemented the solution for exercise 16_range_built_in. The solution demonstrates using Go's range keyword to iterate over built-in types:
  - `sumSlice`: Uses range to iterate over a slice and sum all elements
  - `countMap`: Uses range to iterate over a map and count key-value pairs

  ## Checklist

  - [x] Tests pass: `./bin/golearn verify 16_range_built_in --solution`
  - [x] Docs updated (README/CONTRIBUTING) if needed - No docs changes required
  - [x] No large new dependencies - No new dependencies added

  ## Screenshots / Output (if CLI UX)

  **Solution verification:**
  ==> 16_range_built_in: Range over Built-in Types (solution)
  PASSED 16_range_built_in (solution)

  **Template verification (fails as expected):**
  ==> 16_range_built_in: Range over Built-in Types
  FAILED 16_range_built_in

  **Code quality checks:**
  - ✅ `go vet ./...` - Clean
  - ✅ `gofmt -l .` - All files properly formatted
  - ✅ `go build` - Binary builds successfully

  ## Related issues

  Fixes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new exercise solutions demonstrating range-based iteration, including examples for aggregating slice values and counting entries in maps.
* **Chores**
  * Expanded internal exercise content to support learning and practice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->