### PR TITLE
feat(exercises): add solution for 30_task_scheduler

### DIFF
--- a/internal/exercises/templates/30_task_scheduler/task_scheduler.go
+++ b/internal/exercises/templates/30_task_scheduler/task_scheduler.go
@@ -1,0 +1,17 @@
+package taskscheduler
+
+import "time"
+
+// RunAfter runs a task once after the given delay.
+func RunAfter(delay time.Duration, task func()) {
+	time.Sleep(delay)
+	task()
+}
+
+// RunEvery runs a task multiple times with the given delay between each run.
+func RunEvery(delay time.Duration, count int, task func()) {
+	for i := 0; i < count; i++ {
+		time.Sleep(delay)
+		task()
+	}
+}

--- a/internal/exercises/templates/30_task_scheduler/task_scheduler_test.go
+++ b/internal/exercises/templates/30_task_scheduler/task_scheduler_test.go
@@ -1,0 +1,32 @@
+package taskscheduler
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRunAfter checks if the task runs exactly once after a short delay.
+func TestRunAfter(t *testing.T) {
+	counter := 0
+
+	RunAfter(10*time.Millisecond, func() {
+		counter++
+	})
+
+	if counter != 1 {
+		t.Errorf("expected task to run once, got %d", counter)
+	}
+}
+
+// TestRunEvery checks if the task runs the correct number of times.
+func TestRunEvery(t *testing.T) {
+	counter := 0
+
+	RunEvery(5*time.Millisecond, 3, func() {
+		counter++
+	})
+
+	if counter != 3 {
+		t.Errorf("expected task to run 3 times, got %d", counter)
+	}
+}


### PR DESCRIPTION
Closes #39

This PR adds the solution for the 30_task_scheduler exercise.

Changes:
- Implemented RunAfter to execute a task once after a delay.
- Implemented RunEvery to execute a task multiple times with a fixed delay.
- Added test cases using counters to ensure both functions work correctly.
