### PR TITLE
Add go routines exercise (without PR stacking)

### DIFF
--- a/internal/exercises/catalog.yaml
+++ b/internal/exercises/catalog.yaml
@@ -134,6 +134,11 @@ concepts:
   test_regex: ".*"
   hints:
     - Define a custom error type and return it from a function.
+- slug: 29_go_routines
+  title: Go Routines
+  test_regex: ".*"
+  hints:
+    - Use `go` keyword to execute functions concurrently using go routines.
 - slug: 37_xml
   title: XML Encoding and Decoding
   test_regex: ".*"

--- a/internal/exercises/solutions/29_go_routines/go_routines.go
+++ b/internal/exercises/solutions/29_go_routines/go_routines.go
@@ -1,0 +1,26 @@
+package go_routines
+
+import (
+	"time"
+)
+
+func sleepForOneHundredMillisecond() {
+	time.Sleep(100 * time.Millisecond)
+}
+
+func sleepForTwoHundredMilliseconds() {
+	time.Sleep(200 * time.Millisecond)
+}
+
+func RunConcurrently() {
+	go sleepForOneHundredMillisecond()
+	go sleepForTwoHundredMilliseconds()
+
+	// Alternative solution using anonymous go routines
+	// go func() {
+	// 	sleepForOneHundredMillisecond()
+	// }()
+	// go func() {
+	// 	sleepForTwoHundredMilliseconds()
+	// }()
+}

--- a/internal/exercises/templates/29_go_routines/go_routines.go
+++ b/internal/exercises/templates/29_go_routines/go_routines.go
@@ -1,0 +1,19 @@
+package go_routines
+
+import (
+	"time"
+)
+
+func sleepForOneHundredMillisecond() {
+	time.Sleep(100 * time.Millisecond)
+}
+
+func sleepForTwoHundredMilliseconds() {
+	time.Sleep(200 * time.Millisecond)
+}
+
+func RunConcurrently() {
+	// TODO: update following code to use go routines
+	sleepForOneHundredMillisecond()
+	sleepForTwoHundredMilliseconds()
+}

--- a/internal/exercises/templates/29_go_routines/go_routines_test.go
+++ b/internal/exercises/templates/29_go_routines/go_routines_test.go
@@ -1,0 +1,24 @@
+package go_routines
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGoRoutines(t *testing.T) {
+	start := time.Now()
+	RunConcurrently()
+	elapsed := time.Since(start)
+
+	// according to benchmark it is about ~2 microseconds
+	// x2 for more breathing room, so 4
+	if elapsed.Microseconds() >= 4 {
+		t.Fatal("Go routines was not used!")
+	}
+}
+
+func BenchmarkRunConcurrently(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		RunConcurrently()
+	}
+}


### PR DESCRIPTION
## Summary

Add go routines exercise (without PR stacking)

## Checklist

- [x] Tests pass: `make verify` or `golearn verify <slug>`
- [x] Docs updated (README/CONTRIBUTING) if needed
- [x] No large new dependencies

## Related issues

Fixes #54 
