### PR TITLE
Git ignore binary created due to "go build ./cmd/golearn" command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+golearn
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
## Summary

Git ignore binary created due to "go build ./cmd/golearn" command 

## Checklist

- [x] Tests pass: `make verify` or `golearn verify <slug>`
- [x] Docs updated (README/CONTRIBUTING) if needed
- [x] No large new dependencies

## Related issues

Fixes: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated version control ignore rules to exclude Go workspace artifacts (including golearn).
  - This change affects only repository housekeeping and development workflows.
  - No user-facing functionality or behavior is modified.
  - Builds, performance, and compatibility remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->